### PR TITLE
Clamp Random.nextInt() parameter to a minimum of 1

### DIFF
--- a/src/main/java/cofh/lib/world/feature/FeatureGenLargeVein.java
+++ b/src/main/java/cofh/lib/world/feature/FeatureGenLargeVein.java
@@ -39,6 +39,9 @@ public class FeatureGenLargeVein extends FeatureBase {
 		oreDensity = (oreDensity * 0.01f * (oreDistance >> 1)) + 1f;
 		int i = (int) oreDensity;
 		int rnd = oreDistance / i;
+		// Random.nextInt() will return only 0 if rnd is 1 or less
+		if (rnd <= 1)
+			return 0;
 		int r = 0;
 		for (; i > 0; --i) {
 			r += rand.nextInt(rnd);


### PR DESCRIPTION
While configuring custom ore generation on my server, I ran into a bunch of crashes due to `rnd` becoming 0. This is a good fail-safe check to prevent a complete server crash.